### PR TITLE
🐛 이미지 확장자 import 문제 해결

### DIFF
--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,0 +1,4 @@
+declare module "*.jpg";
+declare module "*.png";
+declare module "*.jpeg";
+declare module "*.gif";

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -5,7 +5,10 @@
       "@components/*": ["./components/*"],
       "@style/*": ["./style/*"],
       "@pages/*": ["./pages/*"],
-      "@utils/*": ["./utils/*"]
+      "@utils/*": ["./utils/*"],
+      "@assets/*": ["./assets/*"],
+      "@services/*": ["./services/*"],
+      "@store/*": ["./store/*"]
     }
   }
 }


### PR DESCRIPTION
## 👩🏻‍💻 작업사항

```
import google from "@assets/auth/google.png";
```
위 처럼 이미지 파일을 import 할 때 파일을 찾지 못하는 문제 발생
정확한 이유는 모르겠으나 TS 문제인 것 같습니다.
src 밑에 custom.d.ts을 추가해 해결했습니다. 

